### PR TITLE
add example of permitting arbitrary function on contract already defined by defi-kit

### DIFF
--- a/roles/creditor_debtor/permissions.ts
+++ b/roles/creditor_debtor/permissions.ts
@@ -9,4 +9,12 @@ export default [
     market: "Core",
     targets: ["USDC", "WETH"],
   }),
+
+  //The above 2 permissions are defined by defi-kit, but here's how
+  //you can permit an arbitrary function on a contract already defined by defi-kit.
+  //(if the contract is not defined by defi-kit, refer to and mimic the eth_wrapping example role)
+  {
+    targetAddress: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2", //AAVE Mainnet v3 Pool, can't go in contracts.ts or it'll conflict
+    signature: "repayWithATokens(address,uint256,uint256)",
+  },
 ] satisfies Permissions;


### PR DESCRIPTION
ChatGPT helped me figure out how to do this.... but I couldn't figure out how to put conditions on the args. I tried:
```
{
  targetAddress: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
  signature: "repayWithATokens(address,uint256,uint256)",
  condition: c.eq("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
},
```
but with no luck. i don't necessarily need conditions on repayWithATokens, but I'm still curious for future reference :-P