### PR TITLE
Update @zodiac-os/sdk to latest and stop documenting the sunset Roles app flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # permissions-starter-kit
 
-Out of the box starting point for managing [Zodiac Roles](https://roles.gnosisguild.org) permissions
+Out of the box starting point for managing [Zodiac Roles](https://docs.roles.gnosisguild.org) permissions
 
 Keep the configuration of your Zodiac Roles Modifier as declarative statements in code.
 The provided tooling automatically applies updates in a consistent and efficient way.
@@ -33,7 +33,7 @@ To initialize the project, open a terminal window and run the following command 
 
 Roles are defined as folders in the [roles/](./roles) directory.
 Folder names correspond to [role keys](#role-keys).
-The template includes two example roles: `eth_wrapping` and `position_management`.
+The template includes four example roles: `creditor_debtor`, `eth_wrapping`, `position_management`, and `swapper`.
 You can either rename these folders or create new ones for your role.
 
 Inside the role folder, create or edit the _permissions.ts_ file with the following boilerplate content:
@@ -128,7 +128,8 @@ For example, to apply the role `eth_wrapping` to a mainnet Roles mod at address 
 yarn apply eth_wrapping eth:0x1234123412341234123412341234123412341234
 ```
 
-This will direct you to the Roles app, where you can review the updates that will be made to your role and confirm them by signing the apply transaction.
+The first time you apply, the CLI authorizes this directory with your [Zodiac organization](https://app.zodiac.eco): it opens a browser to mint an API key and saves it to `.env`.
+It then pushes the update to your workspace and prints a link to the Zodiac app, where you can review the changes and deploy them by signing the transaction.
 
 Applying permissions for the first time will create a new role.
 Subsequent applications will update the existing role, efficiently removing, updating, and adding permissions so that the role configuration on chain accurately reflects the permissions defined in code.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@safe-global/api-kit": "^2.3.0",
     "@types/node": "^20.12.7",
     "@types/yargs": "^17.0.33",
-    "@zodiac-os/sdk": "^1.11.0",
+    "@zodiac-os/sdk": "^1.11.2",
     "defi-kit": "^2.26.10",
     "dotenv": "^17.0.0",
     "ethers": "^6.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,10 +387,10 @@
     zod "^4.1.11"
     zodiac-roles-sdk "^3.4.4"
 
-"@zodiac-os/sdk@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@zodiac-os/sdk/-/sdk-1.11.0.tgz#1eb9b8ed3d101b9a309ff2819ff267aa7f013485"
-  integrity sha512-W++RwXoDFymLiiBL/EZK0LJ2CdM55e30AhMk+5z2FZuz/TD4jwbnk+xoYugvI53+xtqnWcBaOuIHxN4tRCIOkg==
+"@zodiac-os/sdk@^1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@zodiac-os/sdk/-/sdk-1.11.2.tgz#85e0754d6995237ec7567b5d9afe9e3c6433e809"
+  integrity sha512-cBFg+MSDJa3+9HxSlYMGNsR/bYHSM8VK+S7uinGF3Irb7qFyjqNJoxm/C2l23vrjes4bT/lPNNox+u4uCHJ0Dg==
   dependencies:
     "@epic-web/invariant" "1.0.0"
     "@zodiac-os/api-types" "1.6.0"


### PR DESCRIPTION
## What

- **Bump `@zodiac-os/sdk` to `^1.11.2`** (latest).
- **README accuracy fixes** — the apply flow no longer routes through the Roles app (`roles.gnosisguild.org`), which is sunset and kept only as a code-level fallback in `applyLegacy.ts`:
  - The **Apply Updates** section now describes the actual `@zodiac-os/sdk` flow — first-run CLI authorization with your Zodiac org (browser → API key in `.env`), then push-to-workspace and review/deploy in the Zodiac app — instead of "this will direct you to the Roles app … sign the apply transaction".
  - Intro link points to the SDK docs (`docs.roles.gnosisguild.org`) rather than the sunset app.
  - Corrected the example-role count: the template ships **four** roles (`creditor_debtor`, `eth_wrapping`, `position_management`, `swapper`), not two.

## Notes

- Installed with a lockfile-respecting `yarn install` to keep `ethers` deduped at a single version. A naive `yarn upgrade` splits `ethers` into `6.13.5` (root) and `6.17.0` (nested under `zodiac-roles-sdk`), which breaks the `allow.*` kit types because the kit's `BaseContract` and the generated eth-sdk client's contract types then come from different `ethers` copies (collapsing to `never`). `yarn.lock` change is limited to the `@zodiac-os/sdk` bump.

## Verification

- `tsc` compiles cleanly.
- Ran the full `yarn apply` e2e flow end-to-end (CLI auth → `pull-org` → `constellation()` → `push()`); the Zodiac app rendered the expected role diff at the returned review URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)