### PR TITLE
fix: surface HTTP errors from the diff-view prewarm fetch

### DIFF
--- a/.lib/scripts/applyLegacy.ts
+++ b/.lib/scripts/applyLegacy.ts
@@ -104,7 +104,12 @@ async function main() {
 
   const diffUrl = `${ZODIAC_ROLES_APP}/${modArg}/roles/${roleArg}/diff/${hash}`;
   console.log("Preparing diff view...");
-  await fetch(diffUrl);
+  const diffResponse = await fetch(diffUrl);
+  if (!diffResponse.ok) {
+    console.warn(
+      `Diff view responded with HTTP ${diffResponse.status} — the page may not render correctly: ${diffUrl}`,
+    );
+  }
 
   let ownedBySafe = false;
   const owner = ownerAddress && getAddress(ownerAddress);


### PR DESCRIPTION
`applyLegacy.ts` prewarms the diff page with `await fetch(diffUrl)` but ignores the response entirely. That silence masked a months-long SSR 500 on diff pages for governor-owned mods (fixed in gnosisguild/zodiac-modifier-roles#489) — every push "succeeded" while the page users were sent to was broken.

Now a non-2xx response logs a warning with the status code and URL. Warning rather than failing: the push itself succeeded, and the page may still be usable client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012my5oZkF1tFnhsXcNzSkKV